### PR TITLE
Allow users to specify the directory where queries are saved.

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,14 @@ So it will collect the audience for all of the combinations specified in the inp
 
     from pysocialwatcher import constants
     constants.SAVE_EVERY = 1000
+  
+##### Specify that results should be saved to the directory `data/pySocialWatcher/test_query_results/`
+
+    watcher.run_data_collection("pySocialWatcher/pysocialwatcher/quick_example.json", 
+                                "data/pySocialWatcher/test_query_results/")
+
+_Note: Assumes that the directory already exists. Filepath is added to the beginning of the output `.csv` files generated._ 
+
 
 ### Potential Issues:
 1. If you received the error: *You are calling a deprecated version of the Ads API*, means that Facebook updated the API. One way to fix is changing the first 3 variables of the constants.py file to the current Facebook API. This does not guarantee that everything will work.

--- a/pysocialwatcher/main.py
+++ b/pysocialwatcher/main.py
@@ -124,7 +124,7 @@ class PySocialWatcher:
         return json_data
 
     @staticmethod
-    def build_collection_dataframe(input_data_json):
+    def build_collection_dataframe(input_data_json, output_dir = ""):
         print_info("Building Collection Dataframe")
         collection_dataframe = build_initial_collection_dataframe()
         collection_queries = []
@@ -137,12 +137,12 @@ class PySocialWatcher:
         dataframe = add_timestamp(dataframe)
         dataframe = add_published_platforms(dataframe, input_data_json)
         if constants.SAVE_EMPTY:
-            dataframe.to_csv(constants.DATAFRAME_SKELETON_FILE_NAME)
-        save_skeleton_dataframe(dataframe)
+            dataframe.to_csv(output_dir + constants.DATAFRAME_SKELETON_FILE_NAME)
+        save_skeleton_dataframe(dataframe, output_dir)
         return dataframe
 
     @staticmethod
-    def perform_collection_data_on_facebook(collection_dataframe):
+    def perform_collection_data_on_facebook(collection_dataframe, output_dir = ""):
         # Call each requests builded
         processed_rows_after_saved = 0
         dataframe_with_uncompleted_requests = collection_dataframe[pd.isnull(collection_dataframe["response"])]
@@ -156,14 +156,14 @@ class PySocialWatcher:
             processed_rows_after_saved += len(responses_list)
             # Save a temporary file
             if processed_rows_after_saved >= constants.SAVE_EVERY:
-                save_temporary_dataframe(collection_dataframe)
+                save_temporary_dataframe(collection_dataframe, output_dir)
                 processed_rows_after_saved = 0
             # Update not_completed_experiments
             dataframe_with_uncompleted_requests = collection_dataframe[pd.isnull(collection_dataframe["response"])]
         print_info("Data Collection Complete")
-        save_temporary_dataframe(collection_dataframe)
+        save_temporary_dataframe(collection_dataframe, output_dir)
         post_process_collection(collection_dataframe)
-        save_after_collecting_dataframe(collection_dataframe)
+        save_after_collecting_dataframe(collection_dataframe, output_dir)
         return collection_dataframe
 
     @staticmethod
@@ -192,12 +192,12 @@ class PySocialWatcher:
                 add_list_of_ANDS_to_input(list_of_ANDS_between_groups, input_data_json)
 
     @staticmethod
-    def run_data_collection(json_input_file_path):
+    def run_data_collection(json_input_file_path, output_dir = ""):
         input_data_json = PySocialWatcher.read_json_file(json_input_file_path)
         PySocialWatcher.expand_input_if_requested(input_data_json)
         PySocialWatcher.check_input_integrity(input_data_json)
-        collection_dataframe = PySocialWatcher.build_collection_dataframe(input_data_json)
-        collection_dataframe = PySocialWatcher.perform_collection_data_on_facebook(collection_dataframe)
+        collection_dataframe = PySocialWatcher.build_collection_dataframe(input_data_json, output_dir)
+        collection_dataframe = PySocialWatcher.perform_collection_data_on_facebook(collection_dataframe, output_dir)
         return collection_dataframe
 
     @staticmethod

--- a/pysocialwatcher/utils.py
+++ b/pysocialwatcher/utils.py
@@ -201,24 +201,24 @@ def save_response_in_dataframe(shared_queue_list, df):
         df.loc[result_index, "response"] = result_response
 
 
-def save_skeleton_dataframe(dataframe):
+def save_skeleton_dataframe(dataframe, output_dir = ""):
     print_info("Saving Skeleton file: " + constants.DATAFRAME_SKELETON_FILE_NAME)
-    dataframe.to_csv(constants.DATAFRAME_SKELETON_FILE_NAME)
+    dataframe.to_csv(output_dir + constants.DATAFRAME_SKELETON_FILE_NAME)
 
-def save_temporary_dataframe(dataframe):
+def save_temporary_dataframe(dataframe, output_dir = ""):
     print_info("Saving temporary file: " + constants.DATAFRAME_TEMPORARY_COLLECTION_FILE_NAME)
-    dataframe.to_csv(constants.DATAFRAME_TEMPORARY_COLLECTION_FILE_NAME)
+    dataframe.to_csv(output_dir + constants.DATAFRAME_TEMPORARY_COLLECTION_FILE_NAME)
 
 
-def save_after_collecting_dataframe(dataframe):
+def save_after_collecting_dataframe(dataframe, output_dir = ""):
     print_info("Saving after collecting file: " + constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME)
-    dataframe.to_csv(constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME)
+    dataframe.to_csv(output_dir + constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME)
 
-def save_after_collecting_dataframe_without_full_response(dataframe):
+def save_after_collecting_dataframe_without_full_response(dataframe, output_dir = ""):
     dataframe = dataframe.drop('response', 1)
     print_dataframe(dataframe)
     print_info("Saving after collecting file: " + constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME_WITHOUT_FULL_RESPONSE)
-    dataframe.to_csv(constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME_WITHOUT_FULL_RESPONSE)
+    dataframe.to_csv(output_dir + constants.DATAFRAME_AFTER_COLLECTION_FILE_NAME_WITHOUT_FULL_RESPONSE)
 
 
 def print_warning(message):


### PR DESCRIPTION
Add an optional second argument to `run_data_collection()`, called `output_dir`. 
- This argument allows users to specify the directory filepath where pySocialWatcher's output should be saved.  
- The argument supplied is pre-pended to the filenames of the CSVs that are generated by the program: `dataframe_skeleton_*`, `dataframe_collecting_*`, `dataframe_collected_finished_*`, and `collect_finished_clean_*`.

This will be helpful to users who generate many files and want to easily see which CSVs correspond to which queries; they can create directories with informative names and store the CSVs inside.