### PR TITLE
Updated to new MAU ranges (lower and upper bound)

### DIFF
--- a/pysocialwatcher/constants.py
+++ b/pysocialwatcher/constants.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import time
-REACHESTIMATE_URL = "https://graph.facebook.com/v11.0/act_{}/delivery_estimate"
-GRAPH_SEARCH_URL = "https://graph.facebook.com/v11.0/search"
-TARGETING_SEARCH_URL = "https://graph.facebook.com/v11.0/act_{}/targetingsearch"
+REACHESTIMATE_URL = "https://graph.facebook.com/v12.0/act_{}/delivery_estimate"
+GRAPH_SEARCH_URL = "https://graph.facebook.com/v12.0/search"
+TARGETING_SEARCH_URL = "https://graph.facebook.com/v12.0/act_{}/targetingsearch"
 SAVE_EMPTY = True
 SLEEP_TIME = 8
 SAVE_EVERY = 300
@@ -42,6 +42,8 @@ TARGETING_SPEC_FIELD = "targeting_spec"
 RESPONSE_FIELD = "response"
 DAU_AUDIENCE_FIELD = "dau_audience"
 MAU_AUDIENCE_FIELD = "mau_audience"
+MAU_UPPER_AUDIENCE_FIELD = "mau_audience_upper_bound"
+MAU_LOWER_AUDIENCE_FIELD = "mau_audience_lower_bound"
 ALLFIELDS_FIELD = "all_fields"
 INPUT_NAME_FIELD = "name"
 PERFORM_AND_BETWEEN_GROUPS_INPUT_FIELD = "perform_AND_between_groups"
@@ -81,7 +83,7 @@ INPUT_FIELDS_TO_COMBINE = [
     INPUT_HOUSEHOLD_COMPOSITION_FIELD
 ]
 
-DATAFRAME_COLUMNS = [INPUT_NAME_FIELD] + INPUT_FIELDS_TO_COMBINE + [ALLFIELDS_FIELD, TARGETING_FIELD, RESPONSE_FIELD, DAU_AUDIENCE_FIELD, MAU_AUDIENCE_FIELD ]
+DATAFRAME_COLUMNS = [INPUT_NAME_FIELD] + INPUT_FIELDS_TO_COMBINE + [ALLFIELDS_FIELD, TARGETING_FIELD, RESPONSE_FIELD, DAU_AUDIENCE_FIELD, MAU_AUDIENCE_FIELD, MAU_UPPER_AUDIENCE_FIELD, MAU_LOWER_AUDIENCE_FIELD ]
 
 ALLOWED_FIELDS_IN_INPUT = DATAFRAME_COLUMNS + [PERFORM_AND_BETWEEN_GROUPS_INPUT_FIELD] + [API_PUBLISHER_PLATFORMS_FIELD]
 

--- a/pysocialwatcher/utils.py
+++ b/pysocialwatcher/utils.py
@@ -340,7 +340,21 @@ def process_dau_audience_from_response(literal_response):
 
 def process_mau_audience_from_response(literal_response):
     aud = json.loads(literal_response)["data"][0]
-    audience=aud["estimate_mau"]
+    if "estimate_mau" in aud:
+        audience=int(aud["estimate_mau"])
+    else:
+        audience=None
+    return audience
+
+def process_mau_upper_audience_from_response(literal_response):
+    aud = json.loads(literal_response)["data"][0]
+    audience=aud["estimate_mau_upper_bound"]
+    return int(audience)
+
+
+def process_mau_lower_audience_from_response(literal_response):
+    aud = json.loads(literal_response)["data"][0]
+    audience=aud["estimate_mau_lower_bound"]
     return int(audience)
 
 
@@ -353,6 +367,12 @@ def post_process_collection(collection_dataframe):
     collection_dataframe["mau_audience"] = collection_dataframe["response"].apply(
         lambda x: process_mau_audience_from_response(x))
 
+    collection_dataframe["mau_audience_upper_bound"] = collection_dataframe["response"].apply(
+        lambda x: process_mau_upper_audience_from_response(x))
+
+    collection_dataframe["mau_audience_lower_bound"] = collection_dataframe["response"].apply(
+        lambda x: process_mau_lower_audience_from_response(x))
+    
     collection_dataframe = add_mocked_column(collection_dataframe)
     return collection_dataframe
 


### PR DESCRIPTION
Hi Matheus,

FB API now returns a range of MAU values (one lower bound and one upper bound) and the single MAU estimate will be deprecated from November 15th. This update enables the library to save these range estimates as two new columns in the output dataframe.

https://developers.facebook.com/blog/post/2021/09/30/updates-potential-reach-pre-campaign-estimates/

Also updated to the latest API version 12.0
