### PR TITLE
Removes the deprecated currency field in api calls

### DIFF
--- a/pysocialwatcher/utils.py
+++ b/pysocialwatcher/utils.py
@@ -96,7 +96,7 @@ def send_request(url, params, tryNumber = 0):
 def call_request_fb(row, token, account):
     target_request = row[constants.TARGETING_FIELD]
     payload = {
-        'currency': 'USD',
+        #'currency': 'USD',
         'optimize_for': "NONE",
         'optimization_goal': "AD_RECALL_LIFT",
         'targeting_spec': json.dumps(target_request),


### PR DESCRIPTION
Currency is no longer a valid spec in the delivery estimate targeting call. It has been commented out. This should resolve errors with the library.